### PR TITLE
renamed province to view all stores

### DIFF
--- a/react/components/ProvinceSelector.tsx
+++ b/react/components/ProvinceSelector.tsx
@@ -5,7 +5,7 @@ import { Dropdown } from 'vtex.styleguide'
 import { saveStoresFilter } from '../utils'
 
 const ZAF = [
-  { value: '', label: 'Province' },
+  { value: '', label: 'View all stores' },
   { value: 'Eastern Cape', label: 'Eastern Cape' },
   { value: 'Free State', label: 'Free State' },
   { value: 'Gauteng', label: 'Gauteng' },
@@ -26,7 +26,7 @@ const ProvinceSelector = ({
   storesFilter,
   setStoresFilter,
 }: ProvinceSelectorProps) => {
-  const handleChange = (_, value) => {
+  const handleChange = (_, value: string) => {
     setStoresFilter((prevState) => ({ ...prevState, province: value }))
     saveStoresFilter('province', value)
   }


### PR DESCRIPTION
### What problem is this solving?
Renamed Province to View all stores as requested by hein

#### How it works
https://bpf506--thefoschini.myvtex.com/store-finder

#### How to test it?
https://bpf506--thefoschini.myvtex.com/store-finder

### Screenshots/Video example usage:
<img width="725" alt="Screenshot 2022-12-22 at 12 02 56" src="https://user-images.githubusercontent.com/27976086/209109592-6824dda6-3876-4fa8-94df-30cecbf9b32a.png">


### Related to / Depends on
https://github.com/TFG-Labs/vtex-shop/pull/394

#### How does this PR make you feel? :link:
good