### PR TITLE
fix - auth token for requests

### DIFF
--- a/node/utils/Hub.ts
+++ b/node/utils/Hub.ts
@@ -32,9 +32,9 @@ export default class RequestHub extends ExternalClient {
       ...options,
       headers: {
         Accept: 'application/json',
-        'Proxy-Authorization': context.authToken,
-        Authorization: context.authToken,
-        VtexIdclientAutCookie: context.authToken,
+        'Content-type': 'application/json',
+        Authorization: context.adminUserAuthToken ?? context.authToken ?? '',
+        VtexIdclientAutCookie: context.adminUserAuthToken ?? context.authToken ?? '',
       },
     })
     this.logger = new Logger(context)


### PR DESCRIPTION
#### What problem is this solving?

auth token missing in our requests

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace - bash.com?workspace=predeploy](https://bash.com/store-finder?workspace=predeploy)
https://bash.com/store-finder?workspace=predeploy

#### Screenshots or example usage:

![Screenshot 2024-06-28 at 12 31 39](https://github.com/vtex-apps/store-locator/assets/8531068/46413880-712c-43a5-aefe-c8fd9c8d927c)
![Screenshot 2024-06-28 at 12 31 17](https://github.com/vtex-apps/store-locator/assets/8531068/538f9c00-25b6-45e2-84fd-961fb105888a)
![Screenshot 2024-06-25 at 21 29 14](https://github.com/vtex-apps/store-locator/assets/8531068/6949b27e-cfbf-4a2b-bd75-fad2001d72e3)
![Screenshot 2024-06-25 at 21 29 03](https://github.com/vtex-apps/store-locator/assets/8531068/97b442f8-818f-4e6a-bc99-4afc89d001ce)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWsxemg4N3Q4dGFxazlwenVwdWlraTN3dTRobXRvaXR5ZHNuaGY0ZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fdXPD63QKxsY6jYRDz/giphy.gif)
